### PR TITLE
Use GOOS and GOARCH on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build-go: build-n0core build-n0cli
 
 .PHONY: build-n0core
 build-n0core:
-	go build -o bin/n0core -ldflags "-X main.version=$(VERSION)" -v ./n0core/cmd/n0core
+	GOOS=${GOOS} GOARCH=${GOARCH} go build -o bin/n0core -ldflags "-X main.version=$(VERSION)" -v ./n0core/cmd/n0core
 
 .PHONY: build-n0core-on-docker
 build-n0core-on-docker:
@@ -41,7 +41,7 @@ build-n0core-on-docker:
 
 .PHONY: build-n0cli
 build-n0cli:
-	go build -o bin/n0cli -ldflags "-X main.version=$(VERSION)" -v ./n0cli/cmd/n0cli
+	GOOS=${GOOS} GOARCH=${GOARCH} go build -o bin/n0cli -ldflags "-X main.version=$(VERSION)" -v ./n0cli/cmd/n0cli
 
 .PHONY: build-n0cli-on-docker
 build-n0cli-on-docker:
@@ -76,7 +76,7 @@ build-n0proto-on-docker:
 
 .PHONY: build-n0version
 build-n0version:
-	go build -o bin/n0version -ldflags "-X main.version=$(VERSION)" -v ./build/n0version
+	GOOS=${GOOS} GOARCH=${GOARCH} go build -o bin/n0version -ldflags "-X main.version=$(VERSION)" -v ./build/n0version
 
 
 # -- Maintenance ---


### PR DESCRIPTION
## What / 変更点

Makefile の1, 2行目に定義されている `GOOS`, `GOARCH` が使われていなかったため、使うようにした

## Why / 変更した理由

- macOS 上でクロスコンパイルを可能にするため
- n0core は Linux 上で動かすことを想定しているためこれで良い
  - `n0cli` については要検討

## How (Optional) / 概要

## How affect / 影響範囲

特になし
