### PR TITLE
Retry selecting new VNC port when conflicts

### DIFF
--- a/n0core/pkg/driver/qemu/command.go
+++ b/n0core/pkg/driver/qemu/command.go
@@ -150,6 +150,7 @@ func (q *Qemu) Start(id uuid.UUID, qmpPath string, vncWebsocketPort uint16, vcpu
 		return fmt.Errorf("Failed to get absolute path of qmpPath: err='%s'", err.Error())
 	}
 
+retry:
 	args := []string{
 		"qemu-system-x86_64",
 
@@ -244,6 +245,12 @@ func (q *Qemu) Start(id uuid.UUID, qmpPath string, vncWebsocketPort uint16, vcpu
 	cmd := exec.Command(args[0], args[1:]...)
 	out, err := cmd.CombinedOutput()
 	if err != nil { // TODO: combine でもいいかもしれない
+
+		if strings.Contains(string(out), "Failed to start VNC server: Failed to find an available port") {
+			// Retry selecting new port for VNC
+			goto retry
+		}
+
 		return fmt.Errorf("Failed to start process: args='%s', out='%s', err='%s'", args, string(out), err.Error())
 	}
 


### PR DESCRIPTION
## What / 変更点

- VMの作成失敗時に、その理由がVNCのポート衝突であれば再度リトライする

## Why / 変更した理由

- Closes #107

## How (Optional) / 概要

- リトライ時にVNCのポート番号は再度選択されるため、リトライ後には成功することが期待できる

## How affect / 影響範囲

- 特になし
  - そもそもポート番号が枯渇していたら無限ループになるが、現時点では考慮しなくて良い?