### PR TITLE
Implement virtualmachine's shutdown operation

### DIFF
--- a/n0core/pkg/api/provisioning/virtualmachine/agent.go
+++ b/n0core/pkg/api/provisioning/virtualmachine/agent.go
@@ -270,7 +270,42 @@ func (a VirtualMachineAgent) RebootVirtualMachine(ctx context.Context, req *Rebo
 }
 
 func (a VirtualMachineAgent) ShutdownVirtualMachine(ctx context.Context, req *ShutdownVirtualMachineRequest) (*ShutdownVirtualMachineResponse, error) {
-	return nil, grpcutil.WrapGrpcErrorf(codes.Unimplemented, "")
+	q, err := qemu.OpenQemu(SetPrefix(req.Name))
+	if err != nil {
+		return nil, grpcutil.WrapGrpcErrorf(codes.Internal, "Failed to open qemu process: %s", err.Error())
+	}
+	defer q.Close()
+
+	if !q.IsRunning() {
+		return &ShutdownVirtualMachineResponse{
+			State: VirtualMachineState_SHUTDOWN,
+		}, nil
+	}
+
+	if req.Hard {
+		if err := q.HardShutdown(); err != nil {
+			return nil, grpcutil.WrapGrpcErrorf(codes.Internal, "Failed to hard shutdown qemu: %s", err.Error())
+		}
+
+		// after hard shutdown, qemu process exists immediately, so agent can't get status
+		return &ShutdownVirtualMachineResponse{
+			State: VirtualMachineState_SHUTDOWN,
+		}, nil
+	}
+
+	if err := q.Shutdown(); err != nil {
+		return nil, grpcutil.WrapGrpcErrorf(codes.Internal, "Failed to shutdown qemu: %s", err.Error())
+	}
+
+	s, err := q.Status()
+
+	if err != nil {
+		return nil, grpcutil.WrapGrpcErrorf(codes.Internal, "Failed to get status: err=%s", err.Error())
+	}
+
+	return &ShutdownVirtualMachineResponse{
+		State: GetAgentStateFromQemuState(s),
+	}, nil
 }
 
 func (a VirtualMachineAgent) DeleteVirtualMachine(ctx context.Context, req *DeleteVirtualMachineRequest) (*empty.Empty, error) {

--- a/n0core/pkg/api/provisioning/virtualmachine/api.go
+++ b/n0core/pkg/api/provisioning/virtualmachine/api.go
@@ -561,7 +561,7 @@ func (a *VirtualMachineAPI) bootVirtualMachine(ctx context.Context, req *pprovis
 			SshAuthorizedKeys: vm.SshAuthorizedKeys,
 		})
 		if err != nil {
-			return nil, grpcutil.WrapGrpcErrorf(grpc.Code(err), "Failed to CreateVirtualMachineAgent: desc=%s", grpc.ErrorDesc(err))
+			return nil, grpcutil.WrapGrpcErrorf(grpc.Code(err), "Failed to BootVirtualMachine: desc=%s", grpc.ErrorDesc(err))
 		}
 		tx.PushRollback("", func() error {
 			_, err := cli.DeleteVirtualMachine(ctx, &DeleteVirtualMachineRequest{Name: vm.Name})
@@ -585,7 +585,34 @@ func (a *VirtualMachineAPI) RebootVirtualMachine(ctx context.Context, req *pprov
 }
 
 func (a *VirtualMachineAPI) ShutdownVirtualMachine(ctx context.Context, req *pprovisioning.ShutdownVirtualMachineRequest) (*pprovisioning.VirtualMachine, error) {
-	return nil, grpcutil.WrapGrpcErrorf(codes.Unimplemented, "")
+	vm := &pprovisioning.VirtualMachine{}
+	if err := a.dataStore.Get(req.Name, vm); err != nil {
+		log.Printf("[WARNING] Failed to get data from db: err='%s'", err.Error())
+		return nil, grpc.Errorf(codes.Internal, "Failed to get '%s' from db, please retry or contact for the administrator of this cluster", req.Name)
+	} else if vm.Name == "" {
+		return nil, grpc.Errorf(codes.NotFound, "")
+	}
+
+	{
+		cli, done, err := a.getAgent(ctx, vm.ComputeNodeName)
+		if err != nil {
+			return nil, err
+		}
+		defer done()
+
+		res, err := cli.ShutdownVirtualMachine(ctx, &ShutdownVirtualMachineRequest{
+			Name: req.Name,
+			Hard: req.Hard,
+		})
+		if err != nil {
+			return nil, grpcutil.WrapGrpcErrorf(grpc.Code(err), "Failed to ShutdownVirtualMachine: desc=%s", grpc.ErrorDesc(err))
+		}
+
+		// NOTE: shutdown が完了しているとは限らない (ACPIシャットダウンはゲストにより拒否される可能性がある)
+		vm.State = GetAPIStateFromAgentState(res.State)
+	}
+
+	return vm, nil
 }
 
 func (a *VirtualMachineAPI) SaveVirtualMachine(ctx context.Context, req *pprovisioning.SaveVirtualMachineRequest) (*pprovisioning.VirtualMachine, error) {

--- a/n0core/pkg/driver/qemu/command.go
+++ b/n0core/pkg/driver/qemu/command.go
@@ -64,11 +64,7 @@ func (q Qemu) Shutdown() error {
 }
 
 func (q Qemu) HardShutdown() error {
-	if err := q.m.Stop(); err != nil {
-		return err
-	}
-
-	return q.m.SystemReset()
+	return q.m.Quit()
 }
 
 func (q Qemu) Boot() error {


### PR DESCRIPTION
## What / 変更点

- agent と api の `ShutdownVirtualMachine` を実装した
- `func (q Qemu) HardShutdown() error` の実装がおそらくおかしかったため修正した

## Why / 変更した理由

未実装だったため

## How (Optional) / 概要


## How affect / 影響範囲

特になし

シャットダウンが終了することは保証しないため、これに依存するDAGで起動等をすると失敗することは考えられる (新規実装部分であるため、既存影響はない)