### PR TITLE
Implement virtualmachine's hard-reboot (hard-reset) operation

### DIFF
--- a/n0core/pkg/driver/qemu/command.go
+++ b/n0core/pkg/driver/qemu/command.go
@@ -52,11 +52,7 @@ func (q *Qemu) Close() error {
 // }
 
 func (q Qemu) HardReset() error {
-	if err := q.m.SystemReset(); err != nil {
-		return err
-	}
-
-	return q.Boot()
+	return q.m.SystemReset()
 }
 
 func (q Qemu) Shutdown() error {


### PR DESCRIPTION
## What / 変更点

- agent と api の `RebootVirtualMachine` を実装した
- `func (q Qemu) HardReset() error` については `q.m. SystemReset()` でリセット後に起動してくるため、 `Boot()` を呼ばないよう修正

## Why / 変更した理由

未実装だったため

## How (Optional) / 概要

- hard reboot (hard reset) についてはそのまま実装した
- soft reboot の方法が分からなかったため実装せず Unimplemented のままとした

## How affect / 影響範囲

