### PR TITLE
Omit unneeded files to statik

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,9 +115,13 @@ update-go-on-docker:
 .PHONY: update-novnc
 update-novnc:
 	go get -v github.com/rakyll/statik
-	rm -rf /tmp/novnc
+	rm -rf /tmp/novnc /tmp/novnc-statik
 	git clone --depth 1 https://github.com/novnc/noVNC /tmp/novnc
-	statik -p virtualmachine -Z -f -src /tmp/novnc -dest ./n0core/pkg/api/provisioning
+	mkdir /tmp/novnc-statik
+	# Copy only required files, ref: https://github.com/novnc/noVNC/blob/master/docs/EMBEDDING.md
+	cp -r /tmp/novnc/app /tmp/novnc/core /tmp/novnc/vendor /tmp/novnc/*.html /tmp/novnc-statik/
+	statik -p virtualmachine -Z -f -src /tmp/novnc-statik -dest ./n0core/pkg/api/provisioning
+	rm -rf /tmp/novnc /tmp/novnc-statik
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
## What / 変更点

- statik 対象とするファイルを https://github.com/novnc/noVNC のリポジトリ全体ではなく、 `app`, `core`, `vendor`, `*.html` のみに絞るようにした
  - ファイル選択の理由は https://github.com/novnc/noVNC/blob/master/docs/EMBEDDING.md の通り

## Why / 変更した理由

- バイナリのサイズ削減

## How (Optional) / 概要

- api は noVNC を用いたコンソールを提供するため、 https://github.com/novnc/noVNC のリポジトリのファイルを statik で go のソースコードとしてアーカイブし n0core のソース内に保持している

## How affect / 影響範囲

特になし