### PR TITLE
Improve cli

### DIFF
--- a/n0cli/cmd/n0cli/block_storage.go
+++ b/n0cli/cmd/n0cli/block_storage.go
@@ -40,6 +40,7 @@ func listBlockStorage(conn *grpc.ClientConn) error {
 	}
 
 	marshaler.Marshal(os.Stdout, res)
+	fmt.Println()
 
 	return nil
 }
@@ -53,6 +54,7 @@ func getBlockStorage(name string, conn *grpc.ClientConn) error {
 	}
 
 	marshaler.Marshal(os.Stdout, res)
+	fmt.Println()
 
 	return nil
 }
@@ -83,6 +85,7 @@ func deleteBlockStorage(name string, conn *grpc.ClientConn) error {
 	}
 
 	marshaler.Marshal(os.Stdout, res)
+	fmt.Println()
 
 	return nil
 }

--- a/n0cli/cmd/n0cli/delete.go
+++ b/n0cli/cmd/n0cli/delete.go
@@ -44,6 +44,7 @@ func delete(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	case "Network", "network":
 		cl := ppool.NewNetworkServiceClient(conn)
@@ -54,6 +55,7 @@ func delete(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	case "BlockStorage", "block_storage", "bs":
 		cl := pprovisioning.NewBlockStorageServiceClient(conn)
@@ -64,6 +66,7 @@ func delete(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	case "VirtualMachine", "virtual_machine", "vm":
 		cl := pprovisioning.NewVirtualMachineServiceClient(conn)
@@ -74,6 +77,7 @@ func delete(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	case "Image", "image":
 		cl := pdeployment.NewImageServiceClient(conn)
@@ -84,6 +88,7 @@ func delete(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	case "Flavor", "flavor":
 		cl := pdeployment.NewFlavorServiceClient(conn)
@@ -94,6 +99,7 @@ func delete(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	default:
 		return fmt.Errorf("resource type '%s' is not existing\n", resourceType)

--- a/n0cli/cmd/n0cli/get.go
+++ b/n0cli/cmd/n0cli/get.go
@@ -46,6 +46,7 @@ func get(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	case "Network", "network":
 		cl := ppool.NewNetworkServiceClient(conn)
@@ -56,6 +57,7 @@ func get(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	case "BlockStorage", "block_storage", "bs":
 		cl := pprovisioning.NewBlockStorageServiceClient(conn)
@@ -66,6 +68,7 @@ func get(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	case "VirtualMachine", "virtual_machine", "vm":
 		cl := pprovisioning.NewVirtualMachineServiceClient(conn)
@@ -76,6 +79,7 @@ func get(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	case "Image", "image":
 		cl := pdeployment.NewImageServiceClient(conn)
@@ -86,6 +90,7 @@ func get(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	case "Flavor", "flavor":
 		cl := pdeployment.NewFlavorServiceClient(conn)
@@ -96,6 +101,7 @@ func get(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	default:
 		return fmt.Errorf("resource type '%s' is not existing\n", resourceType)
@@ -125,6 +131,7 @@ func list(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	case "Network", "network":
 		cl := ppool.NewNetworkServiceClient(conn)
@@ -135,6 +142,7 @@ func list(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	case "BlockStorage", "block_storage", "bs":
 		cl := pprovisioning.NewBlockStorageServiceClient(conn)
@@ -145,6 +153,7 @@ func list(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	case "VirtualMachine", "virtual_machine", "vm":
 		cl := pprovisioning.NewVirtualMachineServiceClient(conn)
@@ -155,6 +164,7 @@ func list(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	case "Image", "image":
 		cl := pdeployment.NewImageServiceClient(conn)
@@ -165,6 +175,7 @@ func list(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	case "Flavor", "flavor":
 		cl := pdeployment.NewFlavorServiceClient(conn)
@@ -175,6 +186,7 @@ func list(ctx *cli.Context) error {
 		}
 
 		marshaler.Marshal(os.Stdout, res)
+		fmt.Println()
 
 	default:
 		return fmt.Errorf("resource type '%s' is not existing\n", resourceType)

--- a/n0cli/cmd/n0cli/image.go
+++ b/n0cli/cmd/n0cli/image.go
@@ -40,6 +40,7 @@ func listImage(conn *grpc.ClientConn) error {
 	}
 
 	marshaler.Marshal(os.Stdout, res)
+	fmt.Println()
 
 	return nil
 }
@@ -53,6 +54,7 @@ func getImage(name string, conn *grpc.ClientConn) error {
 	}
 
 	marshaler.Marshal(os.Stdout, res)
+	fmt.Println()
 
 	return nil
 }
@@ -83,6 +85,7 @@ func deleteImage(name string, conn *grpc.ClientConn) error {
 	}
 
 	marshaler.Marshal(os.Stdout, res)
+	fmt.Println()
 
 	return nil
 }

--- a/n0cli/cmd/n0cli/main.go
+++ b/n0cli/cmd/n0cli/main.go
@@ -118,6 +118,7 @@ func main() {
 		},
 		{
 			Name:        "network",
+			Aliases:     []string{"net"},
 			Usage:       "Network APIs",
 			Description: "",
 			Subcommands: []cli.Command{
@@ -138,6 +139,7 @@ func main() {
 
 		{
 			Name:        "virtual_machine",
+			Aliases:    []string{"vm"},
 			Usage:       "VirtualMachine APIs",
 			Description: "",
 			Subcommands: []cli.Command{
@@ -161,6 +163,7 @@ func main() {
 				},
 				{
 					Name:      "open_console",
+					Aliases:   []string{"console"},
 					Usage:     "Get URL to open console of VirtualMachine",
 					ArgsUsage: "[VirtualMachine name]",
 					Action:    OpenConsoleOfVirtualMachine,
@@ -169,6 +172,7 @@ func main() {
 		},
 		{
 			Name:        "block_storage",
+			Aliases:     []string{"bs"},
 			Usage:       "BlockStorage APIs",
 			Description: "",
 			Subcommands: []cli.Command{
@@ -232,6 +236,7 @@ func main() {
 			if c2.Name == "get" {
 				getCommand.Subcommands = append(getCommand.Subcommands, cli.Command{
 					Name:      c1.Name,
+					Aliases:   c1.Aliases,
 					Usage:     c2.Usage,
 					ArgsUsage: c2.ArgsUsage,
 					Action:    c2.Action,
@@ -239,6 +244,7 @@ func main() {
 			} else if c2.Name == "delete" {
 				deleteCommand.Subcommands = append(deleteCommand.Subcommands, cli.Command{
 					Name:      c1.Name,
+					Aliases:   c1.Aliases,
 					Usage:     c2.Usage,
 					ArgsUsage: c2.ArgsUsage,
 					Action:    c2.Action,

--- a/n0cli/cmd/n0cli/main.go
+++ b/n0cli/cmd/n0cli/main.go
@@ -29,7 +29,7 @@ func main() {
 	app.Commands = []cli.Command{
 		// 		{
 		// 			Name:      "get",
-		// 			Usage:     "Get resource if set resource name, List resources if not set",
+		// 			Usage:     "Get resource(s)",
 		// 			ArgsUsage: "[resource type] [resource name (optional)]",
 		// 			Description: `
 		// 	## Resource types
@@ -104,7 +104,7 @@ func main() {
 			Subcommands: []cli.Command{
 				{
 					Name:      "get",
-					Usage:     "Get Node if set resource name, List resources if not set",
+					Usage:     "Get Node(s)",
 					ArgsUsage: "[Node name (optional)]",
 					Action:    GetNode,
 				},
@@ -123,7 +123,7 @@ func main() {
 			Subcommands: []cli.Command{
 				{
 					Name:      "get",
-					Usage:     "Get Network if set resource name, List resources if not set",
+					Usage:     "Get Network(s)",
 					ArgsUsage: "[Network name (optional)]",
 					Action:    GetNetwork,
 				},
@@ -143,7 +143,7 @@ func main() {
 			Subcommands: []cli.Command{
 				{
 					Name:      "get",
-					Usage:     "Get VirtualMachine if set resource name, List resources if not set",
+					Usage:     "Get VirtualMachine(s)",
 					ArgsUsage: "[VirtualMachine name (optional)]",
 					Action:    GetVirtualMachine,
 				},
@@ -174,7 +174,7 @@ func main() {
 			Subcommands: []cli.Command{
 				{
 					Name:      "get",
-					Usage:     "Get BlockStorage if set resource name, List resources if not set",
+					Usage:     "Get BlockStorage(s)",
 					ArgsUsage: "[BlockStorage name (optional)]",
 					Action:    GetBlockStorage,
 				},
@@ -199,7 +199,7 @@ func main() {
 			Subcommands: []cli.Command{
 				{
 					Name:      "get",
-					Usage:     "Get Image if set resource name, List resources if not set",
+					Usage:     "Get Image(s)",
 					ArgsUsage: "[Image name (optional)]",
 					Action:    GetImage,
 				},
@@ -215,7 +215,7 @@ func main() {
 
 	getCommand := cli.Command{
 		Name:      "get",
-		Usage:     "Get resource if set resource name, List resources if not set",
+		Usage:     "Get resource(s)",
 		ArgsUsage: "[resource name (optional)]",
 	}
 	deleteCommand := cli.Command{

--- a/n0cli/cmd/n0cli/network.go
+++ b/n0cli/cmd/n0cli/network.go
@@ -40,6 +40,7 @@ func listNetwork(conn *grpc.ClientConn) error {
 	}
 
 	marshaler.Marshal(os.Stdout, res)
+	fmt.Println()
 
 	return nil
 }
@@ -53,6 +54,7 @@ func getNetwork(name string, conn *grpc.ClientConn) error {
 	}
 
 	marshaler.Marshal(os.Stdout, res)
+	fmt.Println()
 
 	return nil
 }
@@ -83,6 +85,7 @@ func deleteNetwork(name string, conn *grpc.ClientConn) error {
 	}
 
 	marshaler.Marshal(os.Stdout, res)
+	fmt.Println()
 
 	return nil
 }

--- a/n0cli/cmd/n0cli/node.go
+++ b/n0cli/cmd/n0cli/node.go
@@ -40,6 +40,7 @@ func listNode(conn *grpc.ClientConn) error {
 	}
 
 	marshaler.Marshal(os.Stdout, res)
+	fmt.Println()
 
 	return nil
 }
@@ -53,6 +54,7 @@ func getNode(name string, conn *grpc.ClientConn) error {
 	}
 
 	marshaler.Marshal(os.Stdout, res)
+	fmt.Println()
 
 	return nil
 }
@@ -83,6 +85,7 @@ func deleteNode(name string, conn *grpc.ClientConn) error {
 	}
 
 	marshaler.Marshal(os.Stdout, res)
+	fmt.Println()
 
 	return nil
 }

--- a/n0cli/cmd/n0cli/virtual_machine.go
+++ b/n0cli/cmd/n0cli/virtual_machine.go
@@ -40,6 +40,7 @@ func listVirtualMachine(conn *grpc.ClientConn) error {
 	}
 
 	marshaler.Marshal(os.Stdout, res)
+	fmt.Println()
 
 	return nil
 }
@@ -53,6 +54,7 @@ func getVirtualMachine(name string, conn *grpc.ClientConn) error {
 	}
 
 	marshaler.Marshal(os.Stdout, res)
+	fmt.Println()
 
 	return nil
 }
@@ -83,6 +85,7 @@ func deleteVirtualMachine(name string, conn *grpc.ClientConn) error {
 	}
 
 	marshaler.Marshal(os.Stdout, res)
+	fmt.Println()
 
 	return nil
 }
@@ -113,6 +116,7 @@ func bootVirtualMachine(name string, conn *grpc.ClientConn) error {
 	}
 
 	marshaler.Marshal(os.Stdout, res)
+	fmt.Println()
 
 	return nil
 }


### PR DESCRIPTION
## What / 変更点

- n0cli の操作後に表示される json の後に改行を追加するようにした
- n0cli の冗長な usage を簡略化
- n0cli において `block_storage` -> `bs`, `netowork` -> `net`, `virtual_machine` -> `vm` のエイリアスを追加

## Why / 変更した理由

使いやすいCLIを目指すため

## How (Optional) / 概要

## How affect / 影響範囲

特になし