### PR TITLE
Implement SIGINT handler for DoDAG

### DIFF
--- a/n0cli/cmd/n0cli/do.go
+++ b/n0cli/cmd/n0cli/do.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
+	"os/signal"
 
 	"github.com/n0stack/n0stack/n0proto.go/pkg/dag"
 	"github.com/urfave/cli"
@@ -43,12 +45,29 @@ func do(ctx *cli.Context) error {
 	defer conn.Close()
 	log.Printf("[DEBUG] Connected to '%s'\n", endpoint)
 
+	ctxCancel, cancel := context.WithCancel(context.Background())
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	defer func() {
+		signal.Stop(c)
+	}()
+
+	go func() {
+		select {
+		case <-c: // SIGINT
+			fmt.Println("---> Wait to finish requested tasks")
+			cancel() // notify DoDAG to cancel
+		case <-ctxCancel.Done():
+			return
+		}
+	}()
+
 	dag.Marshaler = marshaler
 	if err := dag.CheckDAG(tasks); err != nil {
 		return err
 	}
 
-	if ok := dag.DoDAG(tasks, os.Stdout, conn); !ok {
+	if ok := dag.DoDAG(ctxCancel, tasks, os.Stdout, conn); !ok {
 		return fmt.Errorf("Failed to do tasks")
 	}
 

--- a/n0cli/cmd/n0cli/do.go
+++ b/n0cli/cmd/n0cli/do.go
@@ -57,6 +57,7 @@ func do(ctx *cli.Context) error {
 		case <-c: // SIGINT
 			fmt.Println("---> Wait to finish requested tasks")
 			cancel() // notify DoDAG to cancel
+			signal.Stop(c) // allow sending SIGINT again to force SIGINT
 		case <-ctxCancel.Done():
 			return
 		}


### PR DESCRIPTION
Closes #102 

## What / 変更点

- `n0cli do` コマンドの実行中に SIGINT が送られた場合には実行中の DAG Task が終了するまで待つようになる
  - 2度目の SIGINT に対してはこれまでと同様にOS側でハンドリングするようにした (フリーズ防止のため)

## Why / 変更した理由

- `n0cli do` コマンドにおける DAG 実行時に `SIGINT` が送られることでアクションが実行中のままコネクションが切断され、リソースの状態が `PENDING` になることが多発していたため

## How (Optional) / 概要

## How affect / 影響範囲

特になし