### PR TITLE
Build and push n0cli/n0core binaries to GitHub on CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,27 +16,34 @@ jobs:
             git config --global user.name "n0stack bot"
             git config --global user.email "h-otter@outlook.jp"
             echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
-      # - restore_cache:
-      #     keys:
-      #       - vendor-master
-      # - run:
-      #     name: build version
-      #     command: |
-      #       GO111MODULE=on make vendor
-      #       make build-n0version
       - run:
           name: increment version
           command: make increment
       - run:
           name: push
           command: |
+
             git add -f VERSION
             git commit -m "increment version to $(cat VERSION) [skip ci]"
             git push origin master
-      # - save_cache:
-      #     key: vendor-master
-      #     paths:
-      #       - vendor
+      # push n0core and n0cli to GitHub releases
+      - restore_cache:
+          keys:
+            - vendor-master
+      - run:
+          name: install ghr
+          command: |
+            GO111MODULE=on make vendor
+            make release-to-github
+      # - run:
+      #     name: build version
+      #     command: |
+      #       GO111MODULE=on make vendor
+      #       make build-n0core build-n0cli
+      - save_cache:
+          key: vendor-master
+          paths:
+            - vendor
 workflows:
   version: 2
   all:


### PR DESCRIPTION
Closes #110 

## What / 変更点

masterマージ時に GitHub releases へバイナリを登録するようにした

## Why / 変更した理由

常に最新リリースのバイナリを用意に取得したいため

## How (Optional) / 概要

- Makefile へ `release-to-github`, `build-artifacts-to-release` 等のビルドターゲットを追加
  - n0core は linux での動作のみを想定しているため linux のみをビルド対象とし、 n0cli はそれ以外の OSも含むものとした
  - Windows向けは zip, それ以外は tar.gz でアーカイブするようにした
  - GOOS はlinux, darwin, freebsd, windows, GOARCH は amd64 とした

## How affect / 影響範囲

特になし