### PR TITLE
Delete() only delete exact matched value in etcd datastore

### DIFF
--- a/n0core/pkg/datastore/etcd/store.go
+++ b/n0core/pkg/datastore/etcd/store.go
@@ -123,7 +123,7 @@ func (d EtcdDatastore) Delete(key string) error {
 	c, cancel := context.WithTimeout(context.Background(), etcdRequestTimeout)
 	defer cancel()
 
-	_, err := d.client.Delete(c, key, clientv3.WithPrefix())
+	_, err := d.client.Delete(c, key)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #158 

これが意図してない変更であれば PR を close してください

## What / 変更点

- etcd.clientv3 の `KV.Delete` に `clientv3.WithPrefix()` をオプションとして渡さないようにした

## Why / 変更した理由

- 上記のオプションを付けて操作を行うと、 `Delete` を行ったときに引数として渡したキーをプレフィックスとして持つ全ての value を削除するため

## How (Optional) / 概要

## How affect / 影響範囲

なし