### PR TITLE
n0cli get が複数のリソース名を取るように / glob パターンに対応

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/digitalocean/go-libvirt v0.0.0-20181105201604-08f982c676c6 // indirect
 	github.com/digitalocean/go-qemu v0.0.0-20181112162955-dd7bb9c771b8
 	github.com/go-ole/go-ole v1.2.2 // indirect
+	github.com/gobwas/glob v0.2.3
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang/protobuf v1.2.0
 	github.com/google/go-cmp v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/digitalocean/go-qemu v0.0.0-20181112162955-dd7bb9c771b8 h1:N7nH2py78L
 github.com/digitalocean/go-qemu v0.0.0-20181112162955-dd7bb9c771b8/go.mod h1:/YnlngP1PARC0SKAZx6kaAEMOp8bNTQGqS+Ka3MctNI=
 github.com/go-ole/go-ole v1.2.2 h1:HXmymm3IQ8iAfpqlbbUGLHd+SZrnmI4y1pv+WL/3R7c=
 github.com/go-ole/go-ole v1.2.2/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/n0cli/cmd/n0cli/block_storage.go
+++ b/n0cli/cmd/n0cli/block_storage.go
@@ -23,12 +23,17 @@ func GetBlockStorage(c *cli.Context) error {
 
 	if c.NArg() == 0 {
 		return listBlockStorage(conn)
-	} else if c.NArg() == 1 {
-		name := c.Args().Get(0)
-		return getBlockStorage(name, conn)
 	}
 
-	return fmt.Errorf("set valid arguments")
+	for _, name := range c.Args() {
+		err := getBlockStorage(name, conn)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func listBlockStorage(conn *grpc.ClientConn) error {

--- a/n0cli/cmd/n0cli/block_storage.go
+++ b/n0cli/cmd/n0cli/block_storage.go
@@ -6,11 +6,11 @@ import (
 	"log"
 	"os"
 
-	"github.com/n0stack/n0stack/n0proto.go/provisioning/v0"
-
 	"github.com/gobwas/glob"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
+
+	pprovisioning "github.com/n0stack/n0stack/n0proto.go/provisioning/v0"
 )
 
 func GetBlockStorage(c *cli.Context) error {

--- a/n0cli/cmd/n0cli/image.go
+++ b/n0cli/cmd/n0cli/image.go
@@ -10,7 +10,7 @@ import (
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
 
-	"github.com/n0stack/n0stack/n0proto.go/deployment/v0"
+	pdeployment "github.com/n0stack/n0stack/n0proto.go/deployment/v0"
 )
 
 func GetImage(c *cli.Context) error {

--- a/n0cli/cmd/n0cli/image.go
+++ b/n0cli/cmd/n0cli/image.go
@@ -23,12 +23,17 @@ func GetImage(c *cli.Context) error {
 
 	if c.NArg() == 0 {
 		return listImage(conn)
-	} else if c.NArg() == 1 {
-		name := c.Args().Get(0)
-		return getImage(name, conn)
 	}
 
-	return fmt.Errorf("set valid arguments")
+	for _, name := range c.Args() {
+		err := getImage(name, conn)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func listImage(conn *grpc.ClientConn) error {

--- a/n0cli/cmd/n0cli/main.go
+++ b/n0cli/cmd/n0cli/main.go
@@ -81,7 +81,7 @@ func main() {
 				{
 					Name:      "get",
 					Usage:     "Get Node(s)",
-					ArgsUsage: "[Node name (optional)]",
+					ArgsUsage: "[Node name (optional) ...]",
 					Action:    GetNode,
 				},
 				{
@@ -101,7 +101,7 @@ func main() {
 				{
 					Name:      "get",
 					Usage:     "Get Network(s)",
-					ArgsUsage: "[Network name (optional)]",
+					ArgsUsage: "[Network name (optional) ...]",
 					Action:    GetNetwork,
 				},
 				{
@@ -122,7 +122,7 @@ func main() {
 				{
 					Name:      "get",
 					Usage:     "Get VirtualMachine(s)",
-					ArgsUsage: "[VirtualMachine name (optional)]",
+					ArgsUsage: "[VirtualMachine name (optional) ...]",
 					Action:    GetVirtualMachine,
 				},
 				{
@@ -155,7 +155,7 @@ func main() {
 				{
 					Name:      "get",
 					Usage:     "Get BlockStorage(s)",
-					ArgsUsage: "[BlockStorage name (optional)]",
+					ArgsUsage: "[BlockStorage name (optional) ...]",
 					Action:    GetBlockStorage,
 				},
 				{
@@ -180,7 +180,7 @@ func main() {
 				{
 					Name:      "get",
 					Usage:     "Get Image(s)",
-					ArgsUsage: "[Image name (optional)]",
+					ArgsUsage: "[Image name (optional) ...]",
 					Action:    GetImage,
 				},
 				{
@@ -196,7 +196,7 @@ func main() {
 	getCommand := cli.Command{
 		Name:      "get",
 		Usage:     "Get resource(s)",
-		ArgsUsage: "[resource name (optional)]",
+		ArgsUsage: "[resource name (optional) ...]",
 	}
 	deleteCommand := cli.Command{
 		Name:      "delete",

--- a/n0cli/cmd/n0cli/network.go
+++ b/n0cli/cmd/n0cli/network.go
@@ -10,7 +10,7 @@ import (
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
 
-	"github.com/n0stack/n0stack/n0proto.go/pool/v0"
+	ppool "github.com/n0stack/n0stack/n0proto.go/pool/v0"
 )
 
 func GetNetwork(c *cli.Context) error {

--- a/n0cli/cmd/n0cli/network.go
+++ b/n0cli/cmd/n0cli/network.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/gobwas/glob"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
 
@@ -26,6 +27,11 @@ func GetNetwork(c *cli.Context) error {
 	}
 
 	for _, name := range c.Args() {
+		if hasMeta(name) {
+			getNetworkByPattern(name, conn)
+			return nil
+		}
+
 		err := getNetwork(name, conn)
 
 		if err != nil {
@@ -60,6 +66,29 @@ func getNetwork(name string, conn *grpc.ClientConn) error {
 
 	marshaler.Marshal(os.Stdout, res)
 	fmt.Println()
+
+	return nil
+}
+
+func getNetworkByPattern(pattern string, conn *grpc.ClientConn) error {
+	g, err := glob.Compile(pattern)
+	if err != nil {
+		return err
+	}
+
+	cl := ppool.NewNetworkServiceClient(conn)
+	res, err := cl.ListNetworks(context.Background(), &ppool.ListNetworksRequest{})
+	if err != nil {
+		PrintGrpcError(err)
+		return nil
+	}
+
+	for _, network := range res.GetNetworks() {
+		if g.Match(network.Name) {
+			marshaler.Marshal(os.Stdout, network)
+			fmt.Println()
+		}
+	}
 
 	return nil
 }

--- a/n0cli/cmd/n0cli/network.go
+++ b/n0cli/cmd/n0cli/network.go
@@ -23,12 +23,17 @@ func GetNetwork(c *cli.Context) error {
 
 	if c.NArg() == 0 {
 		return listNetwork(conn)
-	} else if c.NArg() == 1 {
-		name := c.Args().Get(0)
-		return getNetwork(name, conn)
 	}
 
-	return fmt.Errorf("set valid arguments")
+	for _, name := range c.Args() {
+		err := getNetwork(name, conn)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func listNetwork(conn *grpc.ClientConn) error {

--- a/n0cli/cmd/n0cli/node.go
+++ b/n0cli/cmd/n0cli/node.go
@@ -10,7 +10,7 @@ import (
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
 
-	"github.com/n0stack/n0stack/n0proto.go/pool/v0"
+	ppool "github.com/n0stack/n0stack/n0proto.go/pool/v0"
 )
 
 func GetNode(c *cli.Context) error {

--- a/n0cli/cmd/n0cli/node.go
+++ b/n0cli/cmd/n0cli/node.go
@@ -23,12 +23,17 @@ func GetNode(c *cli.Context) error {
 
 	if c.NArg() == 0 {
 		return listNode(conn)
-	} else if c.NArg() == 1 {
-		name := c.Args().Get(0)
-		return getNode(name, conn)
 	}
 
-	return fmt.Errorf("set valid arguments")
+	for _, name := range c.Args() {
+		err := getNode(name, conn)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func listNode(conn *grpc.ClientConn) error {

--- a/n0cli/cmd/n0cli/util.go
+++ b/n0cli/cmd/n0cli/util.go
@@ -1,0 +1,9 @@
+package main
+
+import "strings"
+
+// referenced hasMeta() in path/filepath
+func hasMeta(s string) bool {
+	magicChars := `*?[`
+	return strings.ContainsAny(s, magicChars)
+}

--- a/n0cli/cmd/n0cli/virtual_machine.go
+++ b/n0cli/cmd/n0cli/virtual_machine.go
@@ -6,11 +6,11 @@ import (
 	"log"
 	"os"
 
-	"github.com/n0stack/n0stack/n0proto.go/provisioning/v0"
-
 	"github.com/gobwas/glob"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
+
+	pprovisioning "github.com/n0stack/n0stack/n0proto.go/provisioning/v0"
 )
 
 func GetVirtualMachine(c *cli.Context) error {

--- a/n0cli/cmd/n0cli/virtual_machine.go
+++ b/n0cli/cmd/n0cli/virtual_machine.go
@@ -23,12 +23,17 @@ func GetVirtualMachine(c *cli.Context) error {
 
 	if c.NArg() == 0 {
 		return listVirtualMachine(conn)
-	} else if c.NArg() == 1 {
-		name := c.Args().Get(0)
-		return getVirtualMachine(name, conn)
 	}
 
-	return fmt.Errorf("set valid arguments")
+	for _, name := range c.Args() {
+		err := getVirtualMachine(name, conn)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func listVirtualMachine(conn *grpc.ClientConn) error {

--- a/n0cli/cmd/n0cli/virtual_machine.go
+++ b/n0cli/cmd/n0cli/virtual_machine.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/n0stack/n0stack/n0proto.go/provisioning/v0"
 
+	"github.com/gobwas/glob"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
 )
@@ -26,6 +27,11 @@ func GetVirtualMachine(c *cli.Context) error {
 	}
 
 	for _, name := range c.Args() {
+		if hasMeta(name) {
+			getVirtualMachineByPattern(name, conn)
+			return nil
+		}
+
 		err := getVirtualMachine(name, conn)
 
 		if err != nil {
@@ -60,6 +66,29 @@ func getVirtualMachine(name string, conn *grpc.ClientConn) error {
 
 	marshaler.Marshal(os.Stdout, res)
 	fmt.Println()
+
+	return nil
+}
+
+func getVirtualMachineByPattern(pattern string, conn *grpc.ClientConn) error {
+	g, err := glob.Compile(pattern)
+	if err != nil {
+		return err
+	}
+
+	cl := pprovisioning.NewVirtualMachineServiceClient(conn)
+	res, err := cl.ListVirtualMachines(context.Background(), &pprovisioning.ListVirtualMachinesRequest{})
+	if err != nil {
+		PrintGrpcError(err)
+		return nil
+	}
+
+	for _, vm := range res.GetVirtualMachines() {
+		if g.Match(vm.Name) {
+			marshaler.Marshal(os.Stdout, vm)
+			fmt.Println()
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
Closes #135 

## What / 変更点

- `n0cli [type] get` の引数に**複数の**リソースを取れるようにした
  - ex. `n0cli vm get vm_a vm_b`
- `n0cli [type] get` の引数に glob パターンが使えるようになった
  - ex. `n0cli vm get vm_*`

## Why / 変更した理由

n0cli を便利にするため

## How (Optional) / 概要

- 実装がひどいので将来的にリファクタリングする

## How affect / 影響範囲

n0cli [type] get が複数のリソースを返却する際、 valid でない json を返すようになる
本来であれば `{ "VirtualMachines": [...] }` のようにラップして返すほうが良いかもしれないが、現在は`{...} {...}` と複数の `object` が連なって返ってくる。
`jq` はこの入力を正しく受け取ることができるので一般的なユースケースでは問題ないと思うが、将来的には直したほうが良いと思う。