### PR TITLE
n0cli err color

### DIFF
--- a/n0cli/cmd/n0cli/main.go
+++ b/n0cli/cmd/n0cli/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/fatih/color"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
 )
@@ -235,7 +236,9 @@ func main() {
 	log.SetOutput(ioutil.Discard)
 
 	if err := app.Run(os.Args); err != nil {
+		color.Set(color.FgRed)
 		fmt.Fprintf(os.Stderr, "Failed to command: %s\n", err.Error())
+		color.Unset()
 		os.Exit(1)
 	}
 }

--- a/n0proto.go/pkg/dag/dag.go
+++ b/n0proto.go/pkg/dag/dag.go
@@ -235,7 +235,7 @@ func DoDAG(ctx context.Context, tasks map[string]*Task, out io.Writer, conn *grp
 
 		if r.Err != nil {
 			if tasks[r.Name].IgnoreError {
-				color.Set(color.Attribute(91))
+				color.Set(color.FgRed)
 				fmt.Fprintf(out, "---> [ %d/%d ] Task '%s' is failed, ignore error: ", done, total, r.Name)
 				color.Unset()
 				color.Set(color.FgWhite)
@@ -266,7 +266,7 @@ func DoDAG(ctx context.Context, tasks map[string]*Task, out io.Writer, conn *grp
 			res, _ := Marshaler.MarshalToString(r.Res)
 
 			if failed {
-				color.Set(color.FgRed)
+				color.Set(color.Attribute(91))
 				fmt.Fprintf(out, "---> [ %d/%d ] Task '%s', which was requested until failed, is finished\n", done, total, r.Name)
 				color.Unset()
 				color.Set(color.FgWhite)

--- a/n0proto.go/pkg/dag/dag.go
+++ b/n0proto.go/pkg/dag/dag.go
@@ -14,6 +14,7 @@ import (
 	ppool "github.com/n0stack/n0stack/n0proto.go/pool/v0"
 	pprovisioning "github.com/n0stack/n0stack/n0proto.go/provisioning/v0"
 
+	"github.com/fatih/color"
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
 )
@@ -234,9 +235,13 @@ func DoDAG(ctx context.Context, tasks map[string]*Task, out io.Writer, conn *grp
 
 		if r.Err != nil {
 			if tasks[r.Name].IgnoreError {
+				color.Set(color.FgRed)
 				fmt.Fprintf(out, "---> [ %d/%d ] Task '%s' is failed, ignore error: %s\n", done, total, r.Name, r.Err.Error())
+				color.Unset()
 			} else {
+				color.Set(color.FgRed)
 				fmt.Fprintf(out, "---> [ %d/%d ] Task '%s' is failed: %s\n", done, total, r.Name, r.Err.Error())
+				color.Unset()
 
 				if !failed {
 					failed = true
@@ -255,9 +260,13 @@ func DoDAG(ctx context.Context, tasks map[string]*Task, out io.Writer, conn *grp
 			res, _ := Marshaler.MarshalToString(r.Res)
 
 			if failed {
+				color.Set(color.FgRed)
 				fmt.Fprintf(out, "---> [ %d/%d ] Task '%s', which was requested until failed, is finished\n%s\n\n", done, total, r.Name, res)
+				color.Unset()
 			} else {
+				color.Set(color.FgGreen)
 				fmt.Fprintf(out, "---> [ %d/%d ] Task '%s' is finished\n%s\n\n", done, total, r.Name, res)
+				color.Unset()
 			}
 		}
 

--- a/n0proto.go/pkg/dag/dag.go
+++ b/n0proto.go/pkg/dag/dag.go
@@ -235,12 +235,18 @@ func DoDAG(ctx context.Context, tasks map[string]*Task, out io.Writer, conn *grp
 
 		if r.Err != nil {
 			if tasks[r.Name].IgnoreError {
-				color.Set(color.FgRed)
-				fmt.Fprintf(out, "---> [ %d/%d ] Task '%s' is failed, ignore error: %s\n", done, total, r.Name, r.Err.Error())
+				color.Set(color.Attribute(91))
+				fmt.Fprintf(out, "---> [ %d/%d ] Task '%s' is failed, ignore error: ", done, total, r.Name)
+				color.Unset()
+				color.Set(color.FgWhite)
+				fmt.Fprintf(out, "%s\n", r.Err.Error())
 				color.Unset()
 			} else {
 				color.Set(color.FgRed)
-				fmt.Fprintf(out, "---> [ %d/%d ] Task '%s' is failed: %s\n", done, total, r.Name, r.Err.Error())
+				fmt.Fprintf(out, "---> [ %d/%d ] Task '%s' is failed: ", done, total, r.Name)
+				color.Unset()
+				color.Set(color.FgWhite)
+				fmt.Fprintf(out, "%s\n", r.Err.Error())
 				color.Unset()
 
 				if !failed {
@@ -261,11 +267,17 @@ func DoDAG(ctx context.Context, tasks map[string]*Task, out io.Writer, conn *grp
 
 			if failed {
 				color.Set(color.FgRed)
-				fmt.Fprintf(out, "---> [ %d/%d ] Task '%s', which was requested until failed, is finished\n%s\n\n", done, total, r.Name, res)
+				fmt.Fprintf(out, "---> [ %d/%d ] Task '%s', which was requested until failed, is finished\n", done, total, r.Name)
+				color.Unset()
+				color.Set(color.FgWhite)
+				fmt.Fprintf(out, "%s\n\n", res)
 				color.Unset()
 			} else {
 				color.Set(color.FgGreen)
-				fmt.Fprintf(out, "---> [ %d/%d ] Task '%s' is finished\n%s\n\n", done, total, r.Name, res)
+				fmt.Fprintf(out, "---> [ %d/%d ] Task '%s' is finished\n", done, total, r.Name)
+				color.Unset()
+				color.Set(color.FgWhite)
+				fmt.Fprintf(out, "%s\n\n", res)
 				color.Unset()
 			}
 		}


### PR DESCRIPTION
closes #181 

## What / 変更点
n0cliのエラー時と成功した時のメッセージの色を変える。

## Why / 変更した理由
エラーを見逃してしまうので。

## How (Optional) / 概要
github.com/fatih/colorの追加
fmt.Fprintfの前にcolorをsetしておき。後ろでunsetする。

## How affect / 影響範囲
n0proto.go/pkg/dag/dag.go