### PR TITLE
API のテストコードで正解のケースの map を関数に渡さないように修正

### DIFF
--- a/n0core/pkg/api/deployment/image/api_test.go
+++ b/n0core/pkg/api/deployment/image/api_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/n0stack/n0stack/n0core/pkg/api/provisioning"
 	"github.com/n0stack/n0stack/n0core/pkg/datastore/memory"
-	pdeployment "github.com/n0stack/n0stack/n0proto.go/deployment/v0"
-	pprovisioning "github.com/n0stack/n0stack/n0proto.go/provisioning/v0"
+	"github.com/n0stack/n0stack/n0proto.go/deployment/v0"
+	"github.com/n0stack/n0stack/n0proto.go/provisioning/v0"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )

--- a/n0core/pkg/api/deployment/image/api_test.go
+++ b/n0core/pkg/api/deployment/image/api_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/n0stack/n0stack/n0core/pkg/api/provisioning"
 	"github.com/n0stack/n0stack/n0core/pkg/datastore/memory"
-	"github.com/n0stack/n0stack/n0proto.go/deployment/v0"
-	"github.com/n0stack/n0stack/n0proto.go/provisioning/v0"
+	pdeployment "github.com/n0stack/n0stack/n0proto.go/deployment/v0"
+	pprovisioning "github.com/n0stack/n0stack/n0proto.go/provisioning/v0"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )
@@ -137,19 +137,13 @@ func TestImageAboutRegister(t *testing.T) {
 		t.Fatalf("ApplyImage got error: err='%s'", err.Error())
 	}
 
-	bs := &pprovisioning.BlockStorage{
+	bs, err := bsa.CreateBlockStorage(context.Background(), &pprovisioning.CreateBlockStorageRequest{
 		Name: "test-image",
 		Annotations: map[string]string{
 			provisioning.AnnotationRequestNodeName: "mock-node",
 		},
 		RequestBytes: 10 * bytefmt.MEGABYTE,
 		LimitBytes:   1 * bytefmt.GIGABYTE,
-	}
-	_, err = bsa.CreateBlockStorage(context.Background(), &pprovisioning.CreateBlockStorageRequest{
-		Name:         bs.Name,
-		Annotations:  bs.Annotations,
-		RequestBytes: bs.RequestBytes,
-		LimitBytes:   bs.LimitBytes,
 	})
 	if err != nil {
 		t.Fatalf("Failed to create test-image on BlockStorageAPI got error: err='%s'", err.Error())
@@ -187,7 +181,6 @@ func TestImageAboutRegister(t *testing.T) {
 		t.Errorf("Second RegisterBlockStorage got no error")
 	}
 
-
 	rbs, err := bsa.GetBlockStorage(context.Background(), &pprovisioning.GetBlockStorageRequest{Name: bs.Name})
 	if err != nil {
 		t.Errorf("Failed to get test-image on BlockStorageAPI got error: err='%s'", err.Error())
@@ -200,9 +193,11 @@ func TestImageAboutRegister(t *testing.T) {
 		ImageName:        i.Name,
 		Tag:              "test-tag",
 		BlockStorageName: "generated-image",
-		Annotations:      bs.Annotations,
-		RequestBytes:     10 * bytefmt.MEGABYTE,
-		LimitBytes:       10 * bytefmt.GIGABYTE,
+		Annotations: map[string]string{
+			provisioning.AnnotationRequestNodeName: "mock-node",
+		},
+		RequestBytes: 10 * bytefmt.MEGABYTE,
+		LimitBytes:   10 * bytefmt.GIGABYTE,
 	})
 	if err != nil {
 		t.Errorf("Failed to generate BlockStorageAPI got error: err='%s'", err.Error())
@@ -261,19 +256,13 @@ func TestImageAboutTag(t *testing.T) {
 		t.Fatalf("ApplyImage got error: err='%s'", err.Error())
 	}
 
-	bs := &pprovisioning.BlockStorage{
+	bs, err = bsa.CreateBlockStorage(context.Background(), &pprovisioning.CreateBlockStorageRequest{
 		Name: "test-image",
 		Annotations: map[string]string{
 			provisioning.AnnotationRequestNodeName: "mock-node",
 		},
 		RequestBytes: 10 * bytefmt.MEGABYTE,
 		LimitBytes:   1 * bytefmt.GIGABYTE,
-	}
-	_, err = bsa.CreateBlockStorage(context.Background(), &pprovisioning.CreateBlockStorageRequest{
-		Name:         bs.Name,
-		Annotations:  bs.Annotations,
-		RequestBytes: bs.RequestBytes,
-		LimitBytes:   bs.LimitBytes,
 	})
 	if err != nil {
 		t.Fatalf("Failed to create test-image on BlockStorageAPI got error: err='%s'", err.Error())

--- a/n0core/pkg/api/provisioning/blockstorage/api_test.go
+++ b/n0core/pkg/api/provisioning/blockstorage/api_test.go
@@ -54,6 +54,7 @@ func TestCreateBlockStorage(t *testing.T) {
 		Name: "test-block-storage",
 		Annotations: map[string]string{
 			AnnotationBlockStorageRequestNodeName: mnode.Name,
+			AnnotationBlockStorageURL:             "file:///tmp/test-block-storage",
 		},
 		RequestBytes: 1 * bytefmt.GIGABYTE,
 		LimitBytes:   1 * bytefmt.GIGABYTE,
@@ -63,8 +64,10 @@ func TestCreateBlockStorage(t *testing.T) {
 	}
 
 	createRes, err := bsa.CreateBlockStorage(ctx, &pprovisioning.CreateBlockStorageRequest{
-		Name:         bs.Name,
-		Annotations:  bs.Annotations,
+		Name: bs.Name,
+		Annotations: map[string]string{
+			AnnotationBlockStorageRequestNodeName: mnode.Name,
+		},
 		RequestBytes: bs.RequestBytes,
 		LimitBytes:   bs.LimitBytes,
 	})
@@ -115,6 +118,8 @@ func TestFetchBlockStorage(t *testing.T) {
 		Name: "test-block-storage",
 		Annotations: map[string]string{
 			AnnotationBlockStorageRequestNodeName: mnode.Name,
+			AnnotationBlockStorageURL:             "file:///tmp/test-block-storage",
+			AnnotationBlockStorageFetchFrom:       "http://test.local",
 		},
 		RequestBytes: 1 * bytefmt.GIGABYTE,
 		LimitBytes:   1 * bytefmt.GIGABYTE,
@@ -124,8 +129,10 @@ func TestFetchBlockStorage(t *testing.T) {
 	}
 
 	createRes, err := bsa.FetchBlockStorage(ctx, &pprovisioning.FetchBlockStorageRequest{
-		Name:         bs.Name,
-		Annotations:  bs.Annotations,
+		Name: bs.Name,
+		Annotations: map[string]string{
+			AnnotationBlockStorageRequestNodeName: mnode.Name,
+		},
 		RequestBytes: bs.RequestBytes,
 		LimitBytes:   bs.LimitBytes,
 		SourceUrl:    "http://test.local",
@@ -180,6 +187,7 @@ func TestBlockStorageAboutInUseState(t *testing.T) {
 		Name: "test-block-storage",
 		Annotations: map[string]string{
 			AnnotationBlockStorageRequestNodeName: mnode.Name,
+			AnnotationBlockStorageURL:             "file:///tmp/test-block-storage",
 		},
 		RequestBytes: 1 * bytefmt.GIGABYTE,
 		LimitBytes:   1 * bytefmt.GIGABYTE,
@@ -189,8 +197,10 @@ func TestBlockStorageAboutInUseState(t *testing.T) {
 	}
 
 	_, err = bsa.CreateBlockStorage(ctx, &pprovisioning.CreateBlockStorageRequest{
-		Name:         bs.Name,
-		Annotations:  bs.Annotations,
+		Name: bs.Name,
+		Annotations: map[string]string{
+			AnnotationBlockStorageRequestNodeName: mnode.Name,
+		},
 		RequestBytes: bs.RequestBytes,
 		LimitBytes:   bs.LimitBytes,
 	})
@@ -244,6 +254,7 @@ func TestBlockStorageAboutProtectedState(t *testing.T) {
 		Name: "test-block-storage",
 		Annotations: map[string]string{
 			AnnotationBlockStorageRequestNodeName: mnode.Name,
+			AnnotationBlockStorageURL:             "file:///tmp/test-block-storage",
 		},
 		RequestBytes: 1 * bytefmt.GIGABYTE,
 		LimitBytes:   1 * bytefmt.GIGABYTE,
@@ -253,8 +264,10 @@ func TestBlockStorageAboutProtectedState(t *testing.T) {
 	}
 
 	_, err = bsa.CreateBlockStorage(ctx, &pprovisioning.CreateBlockStorageRequest{
-		Name:         bs.Name,
-		Annotations:  bs.Annotations,
+		Name: bs.Name,
+		Annotations: map[string]string{
+			AnnotationBlockStorageRequestNodeName: mnode.Name,
+		},
 		RequestBytes: bs.RequestBytes,
 		LimitBytes:   bs.LimitBytes,
 	})
@@ -308,6 +321,8 @@ func TestCopyBlockStorage(t *testing.T) {
 		Name: "test-block-storage",
 		Annotations: map[string]string{
 			AnnotationBlockStorageRequestNodeName: mnode.Name,
+			AnnotationBlockStorageURL:             "file:///tmp/test-block-storage",
+			AnnotationBlockStorageCopyFrom:        "source",
 		},
 		RequestBytes: 1 * bytefmt.GIGABYTE,
 		LimitBytes:   1 * bytefmt.GIGABYTE,
@@ -317,8 +332,10 @@ func TestCopyBlockStorage(t *testing.T) {
 	}
 
 	src, err := bsa.CreateBlockStorage(ctx, &pprovisioning.CreateBlockStorageRequest{
-		Name:         "source",
-		Annotations:  bs.Annotations,
+		Name: "source",
+		Annotations: map[string]string{
+			AnnotationBlockStorageRequestNodeName: mnode.Name,
+		},
 		RequestBytes: bs.RequestBytes,
 		LimitBytes:   bs.LimitBytes,
 	})
@@ -327,8 +344,10 @@ func TestCopyBlockStorage(t *testing.T) {
 	}
 
 	copyRes, err := bsa.CopyBlockStorage(ctx, &pprovisioning.CopyBlockStorageRequest{
-		Name:         bs.Name,
-		Annotations:  bs.Annotations,
+		Name: bs.Name,
+		Annotations: map[string]string{
+			AnnotationBlockStorageRequestNodeName: mnode.Name,
+		},
 		RequestBytes: bs.RequestBytes,
 		LimitBytes:   bs.LimitBytes,
 
@@ -381,6 +400,7 @@ func TestCopyBlockStorageByLocal(t *testing.T) {
 		Name: "src",
 		Annotations: map[string]string{
 			AnnotationBlockStorageRequestNodeName: mnode.Name,
+			AnnotationBlockStorageURL:             "file:///tmp/test-block-storage",
 		},
 		RequestBytes: 1 * bytefmt.GIGABYTE,
 		LimitBytes:   1 * bytefmt.GIGABYTE,

--- a/n0core/pkg/api/provisioning/virtualmachine/api_test.go
+++ b/n0core/pkg/api/provisioning/virtualmachine/api_test.go
@@ -36,6 +36,31 @@ func TestCreateVirtualMachine(t *testing.T) {
 		t.Fatalf("Failed to factory bloclstorage: err='%s'", err.Error())
 	}
 
+	createRes, err := vma.CreateVirtualMachine(ctx, &pprovisioning.CreateVirtualMachineRequest{
+		Name: "test-virtual-machine",
+		Annotations: map[string]string{
+			AnnotationVirtualMachineRequestNodeName: mnode.Name,
+		},
+
+		LimitCpuMilliCore:   1000,
+		RequestCpuMilliCore: 100,
+		LimitMemoryBytes:    1 * bytefmt.GIGABYTE,
+		RequestMemoryBytes:  1 * bytefmt.GIGABYTE,
+		BlockStorageNames:   []string{bs.Name},
+		Nics: []*pprovisioning.VirtualMachineNIC{
+			{
+				NetworkName: network.Name,
+				// TODO: 決め打ちなので恒常的に正しいとは限らない
+				Ipv4Address:     ip.Next().IP().String(),
+				HardwareAddress: "52:54:78:fe:71:fd",
+			},
+		},
+		Uuid: "1d5fd196-b6c9-4f58-86f2-3ef227018e47",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create virtual machine: err='%s'", err.Error())
+	}
+
 	vm := &pprovisioning.VirtualMachine{
 		Name: "test-virtual-machine",
 		Annotations: map[string]string{
@@ -64,20 +89,6 @@ func TestCreateVirtualMachine(t *testing.T) {
 		NetworkInterfaceNames: []string{"test-virtual-machine0"},
 	}
 
-	createRes, err := vma.CreateVirtualMachine(ctx, &pprovisioning.CreateVirtualMachineRequest{
-		Name:                vm.Name,
-		Annotations:         vm.Annotations,
-		LimitCpuMilliCore:   vm.LimitCpuMilliCore,
-		RequestCpuMilliCore: vm.RequestCpuMilliCore,
-		LimitMemoryBytes:    vm.LimitMemoryBytes,
-		RequestMemoryBytes:  vm.RequestMemoryBytes,
-		BlockStorageNames:   vm.BlockStorageNames,
-		Nics:                vm.Nics,
-		Uuid:                vm.Uuid,
-	})
-	if err != nil {
-		t.Fatalf("Failed to create virtual machine: err='%s'", err.Error())
-	}
 	createRes.XXX_sizecache = 0
 	createRes.Nics[0].XXX_sizecache = 0
 	vm.Nics[0].XXX_sizecache = 0
@@ -131,11 +142,10 @@ func TestCreateVirtualMachineFailedOnNetworkInterface(t *testing.T) {
 		t.Fatalf("Failed to factory bloclstorage: err='%s'", err.Error())
 	}
 
-	vm := &pprovisioning.VirtualMachine{
+	if _, err = vma.CreateVirtualMachine(ctx, &pprovisioning.CreateVirtualMachineRequest{
 		Name: "test-virtual-machine",
 		Annotations: map[string]string{
-			AnnotationVirtualMachineRequestNodeName:  mnode.Name,
-			AnnotationVirtualMachineVncWebSocketPort: "6900",
+			AnnotationVirtualMachineRequestNodeName: mnode.Name,
 		},
 
 		LimitCpuMilliCore:   1000,
@@ -155,25 +165,7 @@ func TestCreateVirtualMachineFailedOnNetworkInterface(t *testing.T) {
 			},
 		},
 		Uuid: "1d5fd196-b6c9-4f58-86f2-3ef227018e47",
-
-		State:                 pprovisioning.VirtualMachine_RUNNING,
-		ComputeNodeName:       mnode.Name,
-		ComputeName:           "test-virtual-machine",
-		NetworkInterfaceNames: []string{"test-virtual-machine0"},
-	}
-
-	_, err = vma.CreateVirtualMachine(ctx, &pprovisioning.CreateVirtualMachineRequest{
-		Name:                vm.Name,
-		Annotations:         vm.Annotations,
-		LimitCpuMilliCore:   vm.LimitCpuMilliCore,
-		RequestCpuMilliCore: vm.RequestCpuMilliCore,
-		LimitMemoryBytes:    vm.LimitMemoryBytes,
-		RequestMemoryBytes:  vm.RequestMemoryBytes,
-		BlockStorageNames:   vm.BlockStorageNames,
-		Nics:                vm.Nics,
-		Uuid:                vm.Uuid,
-	})
-	if err == nil {
+	}); err == nil {
 		t.Fatalf("Create virtual machine do not failed")
 	}
 
@@ -209,11 +201,10 @@ func TestCreateVirtualMachineFailedOnBlockStorage(t *testing.T) {
 		t.Fatalf("Failed to factory bloclstorage: err='%s'", err.Error())
 	}
 
-	vm := &pprovisioning.VirtualMachine{
+	if _, err := vma.CreateVirtualMachine(ctx, &pprovisioning.CreateVirtualMachineRequest{
 		Name: "test-virtual-machine",
 		Annotations: map[string]string{
-			AnnotationVirtualMachineRequestNodeName:  mnode.Name,
-			AnnotationVirtualMachineVncWebSocketPort: "6900",
+			AnnotationVirtualMachineRequestNodeName: mnode.Name,
 		},
 
 		LimitCpuMilliCore:   1000,
@@ -232,25 +223,7 @@ func TestCreateVirtualMachineFailedOnBlockStorage(t *testing.T) {
 			},
 		},
 		Uuid: "1d5fd196-b6c9-4f58-86f2-3ef227018e47",
-
-		State:                 pprovisioning.VirtualMachine_RUNNING,
-		ComputeNodeName:       mnode.Name,
-		ComputeName:           "test-virtual-machine",
-		NetworkInterfaceNames: []string{"test-virtual-machine0"},
-	}
-
-	_, err = vma.CreateVirtualMachine(ctx, &pprovisioning.CreateVirtualMachineRequest{
-		Name:                vm.Name,
-		Annotations:         vm.Annotations,
-		LimitCpuMilliCore:   vm.LimitCpuMilliCore,
-		RequestCpuMilliCore: vm.RequestCpuMilliCore,
-		LimitMemoryBytes:    vm.LimitMemoryBytes,
-		RequestMemoryBytes:  vm.RequestMemoryBytes,
-		BlockStorageNames:   vm.BlockStorageNames,
-		Nics:                vm.Nics,
-		Uuid:                vm.Uuid,
-	})
-	if err == nil {
+	}); err == nil {
 		t.Fatalf("Create virtual machine do not failed")
 	}
 
@@ -286,11 +259,10 @@ func TestDeleteVirtualMachineFailedOnBlockStorage(t *testing.T) {
 		t.Fatalf("Failed to factory bloclstorage: err='%s'", err.Error())
 	}
 
-	vm := &pprovisioning.VirtualMachine{
+	vm, err := vma.CreateVirtualMachine(ctx, &pprovisioning.CreateVirtualMachineRequest{
 		Name: "test-virtual-machine",
 		Annotations: map[string]string{
-			AnnotationVirtualMachineRequestNodeName:  mnode.Name,
-			AnnotationVirtualMachineVncWebSocketPort: "6900",
+			AnnotationVirtualMachineRequestNodeName: mnode.Name,
 		},
 
 		LimitCpuMilliCore:   1000,
@@ -308,23 +280,6 @@ func TestDeleteVirtualMachineFailedOnBlockStorage(t *testing.T) {
 			},
 		},
 		Uuid: "1d5fd196-b6c9-4f58-86f2-3ef227018e47",
-
-		State:                 pprovisioning.VirtualMachine_RUNNING,
-		ComputeNodeName:       mnode.Name,
-		ComputeName:           "test-virtual-machine",
-		NetworkInterfaceNames: []string{"test-virtual-machine0"},
-	}
-
-	vm, err = vma.CreateVirtualMachine(ctx, &pprovisioning.CreateVirtualMachineRequest{
-		Name:                vm.Name,
-		Annotations:         vm.Annotations,
-		LimitCpuMilliCore:   vm.LimitCpuMilliCore,
-		RequestCpuMilliCore: vm.RequestCpuMilliCore,
-		LimitMemoryBytes:    vm.LimitMemoryBytes,
-		RequestMemoryBytes:  vm.RequestMemoryBytes,
-		BlockStorageNames:   vm.BlockStorageNames,
-		Nics:                vm.Nics,
-		Uuid:                vm.Uuid,
 	})
 	if err != nil {
 		t.Fatalf("failed to create virtual machine")


### PR DESCRIPTION
## What / 変更点
API のテストコードで正解のケースの構造体を定義し、関数の返り値となる構造体と比較するというコードがよく見られる。この時、正解となる構造体の一部を関数に引数として渡しているコードがあった。
そこで、関数の呼び出し時には一から新しい構造体を生成するように修正した。

## Why / 変更した理由

この「構造体の一部」が map である時、map が参照型なので関数によって中身が書き換えられ、テストコードが正常に動作しない状態にあった。

## How (Optional) / 概要

## How affect / 影響範囲
API のテストのなかみを修正しただけなので特にないはず。
