### PR TITLE
ロールバック時にエージェントへのコネクションを再取得する

### DIFF
--- a/n0core/pkg/api/provisioning/blockstorage/api.go
+++ b/n0core/pkg/api/provisioning/blockstorage/api.go
@@ -224,6 +224,12 @@ func (a *BlockStorageAPI) CreateBlockStorage(ctx context.Context, req *pprovisio
 			return nil, grpcutil.WrapGrpcErrorf(codes.Internal, "Failed to create block_storage on node '%s': err='%s'", bs.NodeName, err.Error())
 		}
 		tx.PushRollback("DeleteBlockStorage", func() error {
+			cli, done, err := a.getAgent(ctx, bs.NodeName)
+			if err != nil {
+				return err
+			}
+			defer done()
+
 			_, err = cli.DeleteBlockStorage(ctx, &DeleteBlockStorageRequest{Path: v.Path})
 			if err != nil {
 				return err
@@ -319,6 +325,12 @@ func (a *BlockStorageAPI) fetchBlockStorage(ctx context.Context, tx *transaction
 		return grpcutil.WrapGrpcErrorf(codes.Internal, "Failed to FetchBlockStorage on node '%s': err='%s'", bs.NodeName, err.Error())
 	}
 	tx.PushRollback("DeleteBlockStorage", func() error {
+		cli, done, err := a.getAgent(ctx, bs.NodeName)
+		if err != nil {
+			return err
+		}
+		defer done()
+
 		_, err = cli.DeleteBlockStorage(context.Background(), &DeleteBlockStorageRequest{Path: v.Path})
 		if err != nil {
 			return err


### PR DESCRIPTION
## What / 変更点
block storage, virtual machine の API で、ロールバック時もエージェントへのコネクションを新しく取得するようにした

## Why / 変更した理由
fix #200

`getAgent` で得たコネクション `cli` を `defer done()` しているので、その関数実行後に実行されるかもしれないロールバックでは、その `cli` を使ってはいけないから。

## How (Optional) / 概要

## How affect / 影響範囲
特にないはず。
