### PR TITLE
Fix n0core agent deploy (to use os.Executable)

### DIFF
--- a/n0core/pkg/deploy/remote.go
+++ b/n0core/pkg/deploy/remote.go
@@ -96,9 +96,9 @@ func (d RemoteDeployer) SendFile(body []byte, path string, permission os.FileMod
 }
 
 func (d RemoteDeployer) ReadSelf() ([]byte, error) {
-	path, err := filepath.Abs(os.Args[0])
+	path, err := os.Executable()
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get absolute path")
+		return nil, errors.Wrap(err, "Failed to get executable path")
 	}
 
 	if !filepath.IsAbs(path) {
@@ -107,7 +107,7 @@ func (d RemoteDeployer) ReadSelf() ([]byte, error) {
 
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to open self")
+		return nil, errors.Wrap(err, "Failed to open binary itself")
 	}
 	defer file.Close()
 


### PR DESCRIPTION
## What / 変更点

- バイナリ自身のパスを取得するのに `os.Executable()` を使うようにした
  - https://golang.org/pkg/os/#Executable

## Why / 変更した理由

- `n0core agent deploy` コマンドがデプロイ時に自分のパスを正しく取得できないことがあった
  - `os.Args[0]` は `n0core` コマンドを相対パス経由で実行することを期待している (`./n0core`)
  - PATH の中のどこかに `n0core` がある状況において `n0core` で実行していると正しいパスが取得できない

## How (Optional) / 概要

## How affect / 影響範囲
