### PR TITLE
Auto detect node address on ApplyNode if not set

### DIFF
--- a/n0core/pkg/api/pool/node/api.go
+++ b/n0core/pkg/api/pool/node/api.go
@@ -3,11 +3,13 @@ package node
 import (
 	"context"
 	"log"
+	"net"
 	"time"
 
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/n0stack/n0stack/n0core/pkg/datastore"
@@ -72,7 +74,7 @@ func (a NodeAPI) GetNode(ctx context.Context, req *ppool.GetNodeRequest) (*ppool
 
 func (a NodeAPI) ApplyNode(ctx context.Context, req *ppool.ApplyNodeRequest) (*ppool.Node, error) {
 	if req.Name == "" {
-		return nil, grpc.Errorf(codes.InvalidArgument, "Set something to Name")
+		return nil, grpc.Errorf(codes.InvalidArgument, "Name should not be empty")
 	}
 
 	if !a.dataStore.Lock(req.Name) {
@@ -85,10 +87,25 @@ func (a NodeAPI) ApplyNode(ctx context.Context, req *ppool.ApplyNodeRequest) (*p
 		return nil, grpcutil.WrapGrpcErrorf(codes.Internal, datastore.DefaultErrorMessage(err))
 	}
 
+	if len(req.Address) == 0 {
+		p, ok := peer.FromContext(ctx)
+		if !ok {
+			return nil, grpcutil.WrapGrpcErrorf(codes.Internal, "Failed to get gRPC peer information from request")
+		}
+
+		switch addr := p.Addr.(type) {
+		case *net.TCPAddr:
+			res.Address = addr.IP.String()
+		default:
+			return nil, grpc.Errorf(codes.Internal, "Expected peer address is net.TCPAddr, but received %T", addr)
+		}
+	} else {
+		res.Address = req.Address
+	}
+
 	res.Name = req.Name
 	res.Annotations = req.Annotations
 	res.Labels = req.Labels
-	res.Address = req.Address
 	res.IpmiAddress = req.IpmiAddress
 	res.Serial = req.Serial
 	res.CpuMilliCores = req.CpuMilliCores

--- a/n0core/pkg/api/pool/node/api.go
+++ b/n0core/pkg/api/pool/node/api.go
@@ -74,7 +74,7 @@ func (a NodeAPI) GetNode(ctx context.Context, req *ppool.GetNodeRequest) (*ppool
 
 func (a NodeAPI) ApplyNode(ctx context.Context, req *ppool.ApplyNodeRequest) (*ppool.Node, error) {
 	if req.Name == "" {
-		return nil, grpc.Errorf(codes.InvalidArgument, "Name should not be empty")
+		return nil, grpc.Errorf(codes.InvalidArgument, "Name is required")
 	}
 
 	if !a.dataStore.Lock(req.Name) {
@@ -87,7 +87,11 @@ func (a NodeAPI) ApplyNode(ctx context.Context, req *ppool.ApplyNodeRequest) (*p
 		return nil, grpcutil.WrapGrpcErrorf(codes.Internal, datastore.DefaultErrorMessage(err))
 	}
 
-	if len(req.Address) == 0 {
+	res.Name = req.Name
+	res.Annotations = req.Annotations
+	res.Labels = req.Labels
+
+	if req.Address == "" {
 		p, ok := peer.FromContext(ctx)
 		if !ok {
 			return nil, grpcutil.WrapGrpcErrorf(codes.Internal, "Failed to get gRPC peer information from request")
@@ -103,9 +107,6 @@ func (a NodeAPI) ApplyNode(ctx context.Context, req *ppool.ApplyNodeRequest) (*p
 		res.Address = req.Address
 	}
 
-	res.Name = req.Name
-	res.Annotations = req.Annotations
-	res.Labels = req.Labels
 	res.IpmiAddress = req.IpmiAddress
 	res.Serial = req.Serial
 	res.CpuMilliCores = req.CpuMilliCores


### PR DESCRIPTION
## What / 変更点

`n0core agent`に `--advertise-address` を渡さなかった場合、 api 側が `ApplyNode` のリクエストIPを元に自動で検出/設定するようにした

## Why / 変更した理由

- `advertise-address` は n0stack のクラスタ内で `agent` や `api` が互いに通信をするための IP として必要であるが、これはノードの登録時 (`ApplyNode`) を受け取る側からすれば明らかであるため
  - これにより、ほとんどのケースで起動オプションを1つ省略することができセットアップが容易になる

- ただし、あるノードがクラスタのネットワーク内で1つしかIPを持ってないという前提がある
  - 複数IPを持ち、特定のIPを指定したい場合はこれまで通り `--advertise-address` を指定すれば良い

## How (Optional) / 概要

- Go の gRPC ハンドラでは、コンテキストがリクエストのトランスポートに関する情報を持っており、 `grpc/peer#FromContext` でその情報を取得可能
  - https://godoc.org/google.golang.org/grpc/peer

## How affect / 影響範囲

- これまで通り `--advertise-address` を渡していても問題ないため、既存環境に対する影響はない