### PR TITLE
Fix LeveldbStore#List() fails

### DIFF
--- a/n0core/pkg/datastore/store/leveldb/store.go
+++ b/n0core/pkg/datastore/store/leveldb/store.go
@@ -44,7 +44,11 @@ func (ds *LeveldbStore) List() ([][]byte, error) {
 
 	iter := ds.db.NewIterator(util.BytesPrefix([]byte(ds.prefix)), nil)
 	for iter.Next() {
-		res = append(res, iter.Value())
+		// NOTE: iter.Value() doesn't allocate new address for retrieved value,
+		//       so we need to copy it into new array
+		v := make([]byte, len(iter.Value()), len(iter.Value()))
+		copy(v, iter.Value())
+		res = append(res, v)
 	}
 	iter.Release()
 


### PR DESCRIPTION
## What / 変更点

- 表題の通り
  - 具体的には、 `LeveldbStore.List()` の返り値の byteスライスのスライス (`[][]byte`) へ `iter.Value()` の値 (`[]byte`) を追加するときに、値を新たに確保したメモリ領域へコピーするようにした

## Why / 変更した理由

- Go言語の `[][]byte` への append は値ではなく参照を取る
- `iter.Value()` (`iter` は `goleveldb` package の `iterator.Iterator`) は返す値のアドレスを再利用する
- つまり、 `append` は毎回同じアドレスを返り値 (`res`) のスライスへ追加していた
  - 結果として、スライスを構成する3要素 (`Length, Capacity, ZerothElement`) のうち、 `Length` と `Capacity` のみが異なるスライスが返却されていた
  - `proto.Unmarshal` は渡される `byte[]` が正しい長さであることを期待するため、 `Length` がおかしい `protobuf` の wire format を正しく解釈できずエラーが生じていた
  - `proto: ppool.Node: illegal tag 0 (wire type 1)` や `unexpected EOF` といったエラーが出ていたのはそのため

## How (Optional) / 概要

## How affect / 影響範囲
