### PR TITLE
deploy時にパスワード不要で sudo ができる場合はパスワードを尋ねないようにする

### DIFF
--- a/n0core/pkg/deploy/remote.go
+++ b/n0core/pkg/deploy/remote.go
@@ -18,6 +18,7 @@ import (
 
 type RemoteDeployer struct {
 	ssh             *ssh.Client
+	useSudo         bool
 	password        string
 	targetDirectory string
 }
@@ -126,8 +127,12 @@ func (d RemoteDeployer) Command(command string, stdout, stderr io.Writer) error 
 	sess.Stdout = stdout
 	sess.Stderr = stderr
 
-	if len(d.password) > 0 {
-		command = "echo " + d.password + " | sudo -S " + command
+	if d.useSudo {
+		if len(d.password) > 0 {
+			command = "echo " + d.password + " | sudo -S " + command
+		} else {
+			command = "sudo " + command
+		}
 	}
 
 	if err := sess.Run(command); err != nil {
@@ -142,45 +147,81 @@ func (d RemoteDeployer) Command(command string, stdout, stderr io.Writer) error 
 }
 
 func (d *RemoteDeployer) CheckPriv() error {
+	isRemoteRoot, err := d.checkRemoteUserIsRoot()
+	if err != nil {
+		return err
+	}
+
+	if isRemoteRoot {
+		return nil
+	}
+
+	d.useSudo = true
+
+	ok, err := d.trySudoWithoutPassword()
+	if err != nil {
+		return err
+	}
+
+	if ok {
+		return nil
+	}
+
+	for cnt := 0; cnt < 3; cnt++ {
+		sess, err := d.ssh.NewSession()
+		if err != nil {
+			return fmt.Errorf("Failed to create new session")
+		}
+		defer sess.Close()
+
+		fmt.Print("[sudo] input password: ")
+		password, err := terminal.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return fmt.Errorf("Failed to read password")
+		}
+		fmt.Println("checking password...")
+
+		err = sess.Run("echo " + string(password) + " | sudo -S id -u")
+		if err != nil {
+			continue
+		}
+		d.password = string(password)
+		return nil
+	}
+
+	return fmt.Errorf("Wrong password")
+}
+
+func (d *RemoteDeployer) checkRemoteUserIsRoot() (bool, error) {
 	sess, err := d.ssh.NewSession()
 	if err != nil {
-		return fmt.Errorf("Failed to create new session")
+		return false, fmt.Errorf("Failed to create new session")
 	}
 	defer sess.Close()
 
 	out, err := sess.Output("id -u")
 	if err != nil {
-		return fmt.Errorf("Failed to execute `id -u`")
+		return false, fmt.Errorf("Failed to execute `id -u`")
 	}
 	uid, err := strconv.Atoi(strings.TrimRight(string(out), "\n"))
 	if err != nil {
-		return fmt.Errorf("Failed to convert to uid from: %s", out)
+		return false, fmt.Errorf("Failed to convert to uid from: %s", out)
 	}
 
-	if uid != 0 {
-		for cnt := 0; cnt < 3; cnt++ {
-			sess, err := d.ssh.NewSession()
-			if err != nil {
-				return fmt.Errorf("Failed to create new session")
-			}
-			defer sess.Close()
+	return (uid == 0), nil
+}
 
-			fmt.Print("[sudo] input password: ")
-			password, err := terminal.ReadPassword(int(syscall.Stdin))
-			if err != nil {
-				return fmt.Errorf("Failed to read password")
-			}
-			fmt.Println("checking password...")
+func (d *RemoteDeployer) trySudoWithoutPassword() (bool, error) {
+	sess, err := d.ssh.NewSession()
+	if err != nil {
+		return false, fmt.Errorf("Failed to create new session")
+	}
+	defer sess.Close()
 
-			err = sess.Run("echo " + string(password) + " | sudo -S id -u")
-			if err != nil {
-				continue
-			}
-			d.password = string(password)
-			return nil
-		}
-		return fmt.Errorf("Wrong password")
+	out, err := sess.Output("sudo -n echo -n ok")
+	if err != nil {
+		return false, err
 	}
 
-	return nil
+	return string(out) == "ok", nil
 }


### PR DESCRIPTION
## What / 変更点

- 表題の通り
  - `sudo` は `-n` オプションを与えると、パスワードが必要な場合にはエラーメッセージを出して即座に終了する
  - これを利用することで、sudo の実行にパスワードが必要かどうかを判断できる
- \+ 些細なリファクタリング

## Why / 変更した理由

- Ubuntu Cloud Image における `ubuntu` ユーザなど、 `NOPASSWD:ALL` が設定されているユーザで `n0core` をデプロイする状況が存在するため

## How (Optional) / 概要

- sudo の動作確認に使用しているコマンドのみがたまたま許可されていると、デプロイに失敗することが有り得る
  - 既存のコードでも `id` コマンドの実行しかテストしてないので大差なさそう

## How affect / 影響範囲
